### PR TITLE
README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ ES6 Support (Node 6+)
 long - Used for computing the 64-bit output hash.
 int32 - Allows native int32 usage in Node for overflowing.
 
-Installing
+master Installing
 
 npm install dplyer


### PR DESCRIPTION
version: 1.0.0
codeOwners:
  - '0xa988879F0d8A3E5F11163fa309E51178632f976a'
quorum: 1